### PR TITLE
Fixed dead link for common roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dependencies
 - java
 - unzip
 
-Our playbooks provide these dependencies in a [common role](https://github.com/redhat-cop/ansible-middleware-playbooks/tree/master/roles/common), but this there is no explicitly ansible dependency to allow end users more options.
+Our playbooks provide these dependencies in a [common role](https://github.com/redhat-cop/ansible-role-jboss-common), but this there is no explicitly ansible dependency to allow end users more options.
 
 Example Playbooks
 ----------------


### PR DESCRIPTION
Roles were excluded in this commit which causes the dead link:
- https://github.com/redhat-cop/ansible-middleware-playbooks/commit/6407765ebd4e49cbe3e18e82956f4a8c01d1182d